### PR TITLE
caching the cargo related files can help build speeds a lot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,19 @@ jobs:
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-21.11
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - uses: actions/cache@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            .cargo/bin/
+            .cargo/registry/index/
+            .cargo/registry/cache/
+            .cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Configure Nix substituters
         run: |
           set -xe


### PR DESCRIPTION
don't need the nodejs thing because nix is coming with node


i was working on improving all this over in 
https://github.com/lightningrodlabs/electron-holochain-template

could also add caching of node_modules with pnpm-lock file as the cache busting key